### PR TITLE
Update AddTimePickerPlatformEffect.cs

### DIFF
--- a/AiForms.Effects.iOS/AddDatePickerPlatformEffect.cs
+++ b/AiForms.Effects.iOS/AddDatePickerPlatformEffect.cs
@@ -80,7 +80,7 @@ namespace AiForms.Effects.iOS
             _view.UserInteractionEnabled = true;
             _view.SendSubviewToBack(_entry);
 
-            _picker = new UIDatePicker { Mode = UIDatePickerMode.Date, TimeZone = new Foundation.NSTimeZone("UTC") };
+            _picker = new UIDatePicker { Mode = UIDatePickerMode.Date, TimeZone = new Foundation.NSTimeZone("UTC"), PreferredDatePickerStyle = UIDatePickerStyle.Wheels };
             var todayText = AddDatePicker.GetTodayText(Element);
 
             var width = UIScreen.MainScreen.Bounds.Width;

--- a/AiForms.Effects.iOS/AddTimePickerPlatformEffect.cs
+++ b/AiForms.Effects.iOS/AddTimePickerPlatformEffect.cs
@@ -77,7 +77,7 @@ namespace AiForms.Effects.iOS
             _view.UserInteractionEnabled = true;
             _view.SendSubviewToBack(_entry);
 
-            _picker = new UIDatePicker { Mode = UIDatePickerMode.Time, TimeZone = new Foundation.NSTimeZone("UTC") };
+            _picker = new UIDatePicker { Mode = UIDatePickerMode.Time, TimeZone = new Foundation.NSTimeZone("UTC"), PreferredDatePickerStyle = UIDatePickerStyle.Wheels };
             _title = new UILabel();
 
             var width = UIScreen.MainScreen.Bounds.Width;


### PR DESCRIPTION
This will revert back default 'look' for iOS 14 devices.

I was unable to test on a non iOS 14 device however, so we may need something like the following
```csharp
_picker = new UIDatePicker { Mode = UIDatePickerMode.Time, TimeZone = new Foundation.NSTimeZone("UTC") };
if (UIDevice.CurrentDevice.CheckSystemVersion(13, 4))
{
_picker.PreferredDatePickerStyle = UIDatePickerStyle.Wheels;
}
```